### PR TITLE
Fix wrong variable name

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -7,7 +7,7 @@
     <type name="Magento\Config\Model\Config\TypePool">
         <arguments>
             <argument name="sensitive" xsi:type="array">
-                <item name="system/admin/autologin_email" xsi:type="string">1</item>
+                <item name="system/admin/autologin_username" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
Hello,

Thanks for this useful module +1 !
This just fix a wrong variable name in the di.xml
As in other parts of the code, the used variable is system/admin/autologin_**username**

Regards,